### PR TITLE
skip update on allowances on transfer if infinite approved

### DIFF
--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -73,7 +73,10 @@ contract Synth is iERC20 {
         uint256 amount
     ) public virtual override returns (bool) {
         _transfer(sender, recipient, amount);
-        _approve(sender, msg.sender, _allowances[sender][msg.sender] - amount);
+        // Unlimited approval (saves an SSTORE)
+        if (_allowances[sender][msg.sender] < type(uint256).max) {
+            _approve(sender, msg.sender, _allowances[sender][msg.sender] - amount);
+        }
         return true;
     }
 

--- a/contracts/Token1.sol
+++ b/contracts/Token1.sol
@@ -63,7 +63,9 @@ contract Token1 is iERC20 {
         uint256 amount
     ) public virtual override returns (bool) {
         _transfer(sender, recipient, amount);
-        _approve(sender, msg.sender, _allowances[sender][msg.sender] - amount);
+        if (_allowances[sender][msg.sender] < type(uint256).max) {
+            _approve(sender, msg.sender, _allowances[sender][msg.sender] - amount);
+        }
         return true;
     }
 

--- a/contracts/Token2.sol
+++ b/contracts/Token2.sol
@@ -63,7 +63,9 @@ contract Token2 is iERC20 {
         uint256 amount
     ) public virtual override returns (bool) {
         _transfer(sender, recipient, amount);
-        _approve(sender, msg.sender, _allowances[sender][msg.sender] - amount);
+        if (_allowances[sender][msg.sender] < type(uint256).max) {
+            _approve(sender, msg.sender, _allowances[sender][msg.sender] - amount);
+        }
         return true;
     }
 

--- a/contracts/USDV.sol
+++ b/contracts/USDV.sol
@@ -97,7 +97,10 @@ contract USDV is iERC20 {
         uint256 amount
     ) external virtual override returns (bool) {
         _transfer(sender, recipient, amount);
-        _approve(sender, msg.sender, _allowances[sender][msg.sender] - amount);
+        // Unlimited approval (saves an SSTORE)
+        if (_allowances[sender][msg.sender] < type(uint256).max) {
+            _approve(sender, msg.sender, _allowances[sender][msg.sender] - amount);
+        }
         return true;
     }
 

--- a/contracts/Vader.sol
+++ b/contracts/Vader.sol
@@ -117,7 +117,10 @@ contract Vader is iERC20 {
         uint256 amount
     ) external virtual override returns (bool) {
         _transfer(sender, recipient, amount);
-        _approve(sender, msg.sender, _allowances[sender][msg.sender] - amount);
+        // Unlimited approval (saves an SSTORE)
+        if (_allowances[sender][msg.sender] < type(uint256).max) {
+            _approve(sender, msg.sender, _allowances[sender][msg.sender] - amount);
+        }
         return true;
     }
 

--- a/contracts/Vether.sol
+++ b/contracts/Vether.sol
@@ -75,7 +75,10 @@ contract Vether is iVETHER {
         uint256 amount
     ) public virtual override returns (bool) {
         _transfer(sender, recipient, amount);
-        _approve(sender, msg.sender, _allowances[sender][msg.sender] - amount);
+        // Unlimited approval (saves an SSTORE)
+        if (_allowances[sender][msg.sender] < type(uint256).max) {
+            _approve(sender, msg.sender, _allowances[sender][msg.sender] - amount);
+        }
         return true;
     }
 


### PR DESCRIPTION
skip updating `allowances` when `transferFrom`  is called if `allowances[sender][msg.sender]` is set to unlimited.

same code in other projects
https://github.com/yearn/yearn-vaults/blob/master/contracts/Vault.vy#L674-L679