### PR TITLE
ERC20 specifies uint8 decimals

### DIFF
--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -12,7 +12,7 @@ contract Synth is iERC20 {
     // Coin Defaults
     string public override name;
     string public override symbol;
-    uint256 public constant override decimals = 18;
+    uint8 public constant override decimals = 18;
     uint256 public override totalSupply;
 
     // ERC-20 Mappings

--- a/contracts/Token1.sol
+++ b/contracts/Token1.sol
@@ -9,7 +9,7 @@ contract Token1 is iERC20 {
     // Coin Defaults
     string public override name; // Name of Coin
     string public override symbol; // Symbol of Coin
-    uint256 public constant override decimals = 18; // Decimals
+    uint8 public constant override decimals = 18; // Decimals
     uint256 public override totalSupply = 1 * 10**9 * (10**decimals); // 1,000,000 Total
 
     // ERC-20 Mappings

--- a/contracts/Token2.sol
+++ b/contracts/Token2.sol
@@ -9,7 +9,7 @@ contract Token2 is iERC20 {
     // Coin Defaults
     string public override name; // Name of Coin
     string public override symbol; // Symbol of Coin
-    uint256 public constant override decimals = 18; // Decimals
+    uint8 public constant override decimals = 18; // Decimals
     uint256 public override totalSupply = 1 * 10**9 * (10**decimals); // 1,000,000 Total
 
     // ERC-20 Mappings

--- a/contracts/USDV.sol
+++ b/contracts/USDV.sol
@@ -11,7 +11,7 @@ contract USDV is iERC20 {
     // ERC-20 Parameters
     string public constant override name = "VADER STABLE DOLLAR";
     string public constant override symbol = "USDV";
-    uint256 public constant override decimals = 18;
+    uint8 public constant override decimals = 18;
     uint256 public override totalSupply;
 
     // ERC-20 Mappings

--- a/contracts/Vader.sol
+++ b/contracts/Vader.sol
@@ -12,7 +12,7 @@ contract Vader is iERC20 {
     // ERC-20 Parameters
     string public constant override name = "VADER PROTOCOL TOKEN";
     string public constant override symbol = "VADER";
-    uint256 public constant override decimals = 18;
+    uint8 public constant override decimals = 18;
     uint256 public override totalSupply;
 
     // ERC-20 Mappings

--- a/contracts/Vether.sol
+++ b/contracts/Vether.sol
@@ -9,7 +9,7 @@ contract Vether is iVETHER {
     // Coin Defaults
     string public constant override name = "Vether"; // Name of Coin
     string public constant override symbol = "VETH"; // Symbol of Coin
-    uint256 public constant override decimals = 18; // Decimals
+    uint8 public constant override decimals = 18; // Decimals
     uint256 public constant override totalSupply = 1 * 10**6 * (10**decimals); // 1,000,000 Total
 
     uint256 public totalFees;

--- a/contracts/interfaces/iERC20.sol
+++ b/contracts/interfaces/iERC20.sol
@@ -6,7 +6,7 @@ interface iERC20 {
 
     function symbol() external view returns (string memory);
 
-    function decimals() external view returns (uint256);
+    function decimals() external view returns (uint8);
 
     function totalSupply() external view returns (uint256);
 

--- a/contracts/interfaces/iVETHER.sol
+++ b/contracts/interfaces/iVETHER.sol
@@ -6,7 +6,7 @@ interface iVETHER {
 
     function symbol() external view returns (string memory);
 
-    function decimals() external view returns (uint256);
+    function decimals() external view returns (uint8);
 
     function totalSupply() external view returns (uint256);
 


### PR DESCRIPTION
From Certik:

> The iERC20 interface that multiple contracts inherit from (USDV, Synth etc.) defines the decimals member as a uint256 which is incorrect and will cause complete incompatibility with any contract relying on the ERC20 decimals member which is meant to be uint8. We strongly advise this to be changed in both the implementations and interface.