### PR TITLE
Issue184 - compute SynthUnits

### DIFF
--- a/contracts/Utils.sol
+++ b/contracts/Utils.sol
@@ -103,12 +103,15 @@ contract Utils {
 
     function getMemberShare(uint256 basisPoints, address token, address member) external view returns(uint256 units, uint256 outputBase, uint256 outputToken) {
         units = calcPart(basisPoints, iPOOLS(POOLS()).getMemberUnits(token, member));
-        address _synth = iFACTORY(FACTORY()).getSynth(token);
-        uint256 _S = iERC20(_synth).totalSupply();
-        uint256 _P = iPOOLS(POOLS()).getUnits(token);
+        uint256 _totalUnits = iPOOLS(POOLS()).getUnits(token);
+        uint256 _B = iPOOLS(POOLS()).getBaseAmount(token);
         uint256 _T = iPOOLS(POOLS()).getTokenAmount(token);
-        uint256 _totalUnits = _P + calcSynthUnits(_S, _P, _T);
-        outputBase = calcShare(units, _totalUnits, iPOOLS(POOLS()).getBaseAmount(token));
+        address _synth = iFACTORY(FACTORY()).getSynth(token);
+        if(_synth != address(0)){
+            uint256 _S = iERC20(_synth).totalSupply();
+            _totalUnits = _totalUnits + calcSynthUnits(_S, _B, _T);
+        }
+        outputBase = calcShare(units, _totalUnits, _B);
         outputToken = calcShare(units, _totalUnits, _T);
     }
 
@@ -319,11 +322,11 @@ contract Utils {
 
     function calcSynthUnits(
         uint256 S,
-        uint256 P,
+        uint256 B,
         uint256 T
     ) public pure returns (uint256) {
-        // (P * S)/(2 * T)
-        return (P * S) / (2 * T);
+        // (S * B)/(2 * T)
+        return (S * B) / (2 * T);
     }
 
     function calcAsymmetricShare(

--- a/test/9_synths.js
+++ b/test/9_synths.js
@@ -25,7 +25,7 @@ async function setNextBlockTimestamp(ts) {
   await ethers.provider.send('evm_setNextBlockTimestamp', [ts])
   await ethers.provider.send('evm_mine')
 }
-const ts0 = 1830297600 // Sat Jan 01 2028 00:00:00 GMT+0000
+const ts0 = 1830470400 // Sat Jan 03 2028 00:00:00 GMT+0000
 
 const max = '115792089237316195423570985008687907853269984665640564039457584007913129639935'
 
@@ -112,16 +112,19 @@ describe("Should Swap Synths", function() {
 
   it("Swap from Base to Synth", async function() {
     await pools.deploySynth(asset.address)
-    await router.swapWithSynths('250', usdv.address, false, asset.address, true, {from:acc1})
-    expect(BN2Str(await pools.getBaseAmount(asset.address))).to.equal('1250');
-    expect(BN2Str(await pools.getTokenAmount(asset.address))).to.equal('1000');
-    expect(BN2Str(await utils.calcSynthUnits('250', '1000', '1000'))).to.equal('100');
-    expect(BN2Str(await pools.mapTokenMember_Units(asset.address, pools.address))).to.equal('100');
-    expect(BN2Str(await pools.mapToken_Units(asset.address))).to.equal('1100');
-
-    expect(BN2Str(await utils.calcSwapOutput('250', '1000', '1000'))).to.equal('160');
     let synthAddress = await factory.getSynth(asset.address)
     let synth = await Synth.at(synthAddress);
+    await router.swapWithSynths('250', usdv.address, false, asset.address, true, {from:acc1})
+    let S = BN2Str(await synth.totalSupply())
+    let B = BN2Str(await pools.getBaseAmount(asset.address))
+    let T = BN2Str(await pools.getTokenAmount(asset.address))
+    expect(S).to.equal('160');
+    expect(B).to.equal('1250');
+    expect(T).to.equal('1000');
+    expect(BN2Str(await utils.calcSynthUnits(S, B, T))).to.equal('100');
+    expect(BN2Str(await pools.mapToken_Units(asset.address))).to.equal('1000');
+
+    expect(BN2Str(await utils.calcSwapOutput('250', '1000', '1000'))).to.equal('160');
     expect(BN2Str(await synth.balanceOf(acc1))).to.equal('160');
     expect(await synth.name()).to.equal('Token1 - vSynth');
     expect(await synth.symbol()).to.equal('TKN1.v');
@@ -136,8 +139,7 @@ describe("Should Swap Synths", function() {
     expect(BN2Str(await pools.getBaseAmount(asset.address))).to.equal('1165');
     expect(BN2Str(await pools.getTokenAmount(asset.address))).to.equal('1000');
     expect(BN2Str(await utils.calcShare('80', '160', '100'))).to.equal('50');
-    expect(BN2Str(await pools.mapTokenMember_Units(asset.address, pools.address))).to.equal('50');
-    expect(BN2Str(await pools.mapToken_Units(asset.address))).to.equal('1050');
+    expect(BN2Str(await pools.mapToken_Units(asset.address))).to.equal('1000');
   });
 
   it("Swap from Synth to Synth", async function() {
@@ -150,7 +152,6 @@ describe("Should Swap Synths", function() {
     expect(BN2Str(await pools.getBaseAmount(asset2.address))).to.equal('1079');
     expect(BN2Str(await pools.getTokenAmount(asset2.address))).to.equal('1000');
     expect(BN2Str(await utils.calcShare('80', '160', '100'))).to.equal('50');
-    expect(BN2Str(await pools.mapTokenMember_Units(asset.address, pools.address))).to.equal('0');
     expect(BN2Str(await pools.mapToken_Units(asset.address))).to.equal('1000');
     
     expect(BN2Str(await utils.calcSwapOutput('250', '1000', '1000'))).to.equal('160');


### PR DESCRIPTION
Closes #184 

synth units are now computed algorithmicly. They depend purely on synth supply, plus pool depths, are are only just enough to hold enough collateral to preserve exit purchasing power. 

thus LPs experience yield or loss immediately (and no waiting)