### PR TITLE
Factory: get rid of redundant _isSynth mapping

### DIFF
--- a/contracts/Factory.sol
+++ b/contracts/Factory.sol
@@ -10,7 +10,6 @@ contract Factory {
 
     address[] public arraySynths;
     mapping(address => address) private mapToken_Synth;
-    mapping(address => bool) private _isSynth;
 
     event CreateSynth(address indexed token, address indexed pool);
 
@@ -44,12 +43,11 @@ contract Factory {
         return mapToken_Synth[token];
     }
     function isSynth(address token) public view returns (bool _exists){
-        return _isSynth[token];
+        return mapToken_Synth[token] != address(0);
     }
 
     function _addSynth(address _token, address _synth) internal {
         mapToken_Synth[_token] = _synth;
         arraySynths.push(_synth);
-        _isSynth[_synth] = true;
     }
 }

--- a/contracts/Factory.sol
+++ b/contracts/Factory.sol
@@ -25,7 +25,15 @@ contract Factory {
     //Create a synth asset
     function deploySynth(address token) external onlyPOOLS returns (address synth) {
         require(mapToken_Synth[token] == address(0), "CreateErr");
-        synth = address(new Synth(token));
+
+        bytes memory bytecode = type(Synth).creationCode;
+        bytes32 salt = keccak256(abi.encodePacked(token, address(this)));
+        assembly {
+            synth := create2(0, add(bytecode, 32), mload(bytecode), salt)
+        }
+
+        Synth(token).initialize(token);
+
         _addSynth(token, synth);
         emit CreateSynth(token, synth);
     }

--- a/contracts/Pools.sol
+++ b/contracts/Pools.sol
@@ -201,7 +201,7 @@ contract Pools {
         address member
     ) external onlySystem returns (uint256 outputAmount) {
         address synth = getSynth(token);
-        require(iFACTORY(FACTORY()).isSynth(synth), "!Synth");
+        require(synth != address(0), "!Synth");
         uint256 _actualInputBase = getAddedAmount(USDV(), token); // Get input
         outputAmount = iUTILS(UTILS()).calcSwapOutput(
             _actualInputBase,

--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -26,15 +26,16 @@ contract Synth is iERC20 {
     }
 
     // Minting event
-    constructor(address _token) {
-        TOKEN = _token;
+    constructor() {
         FACTORY = msg.sender;
+    }
+    function initialize((address _token) onlyFACTORY {
+        TOKEN = _token;
         string memory synthName = " - vSynth";
         string memory synthSymbol = ".v";
         name = string(abi.encodePacked(iERC20(_token).name(), synthName));
         symbol = string(abi.encodePacked(iERC20(_token).symbol(), synthSymbol));
     }
-
     //========================================iERC20=========================================//
     function balanceOf(address account) external view override returns (uint256) {
         return _balances[account];


### PR DESCRIPTION
Even though this breaks tests, I think we should proceed from something like this, because we will be fixing other code.

We may want to think about making `Factory`'s `getSynth` abort if there is no matching entry to spare ourselves having to check each time after calling it.